### PR TITLE
Fix usage error

### DIFF
--- a/pwhash.go
+++ b/pwhash.go
@@ -49,7 +49,7 @@ func PwHashDeterministic(h_len int, passwd string, ctx string, master_key []byte
 		(*C.char)(unsafe.Pointer(&cCtx[0])),
 		(*C.uint8_t)(&master_key[0]),
 		C.size_t(opslimit),
-		C.size_t(PwHashDeterministicMemLimit),
+		C.ulonglong(PwHashDeterministicMemLimit),
 		C.uint8_t(PwHashDeterministicThreads)))
 
 	return out, exit


### PR DESCRIPTION
This PR fixes an error with `make run`:

```
./pwhash.go:51:11: cannot use _Ctype_ulong(opslimit) (type _Ctype_ulong) as type _Ctype_ulonglong in argument to _Cfunc_hydro_pwhash_deterministic
```